### PR TITLE
fix(deploy): add .dockerignore + aggressive docker prune

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,40 @@
+# Nuxt build outputs — пересобираются в контейнере, тащить с хоста не нужно
+.output
+.nuxt
+.nitro
+.cache
+.data
+dist
+
+# Node deps — ставятся в контейнере через npm i
+node_modules
+
+# Git/VCS
+.git
+.gitignore
+.gitattributes
+
+# CI / locals
+.github
+.idea
+.vscode
+.fleet
+.DS_Store
+
+# Logs
+logs
+*.log
+npm-debug.log*
+
+# Env (билд получает значения через ARG)
+.env
+.env.*
+!.env.example
+
+# Docker meta (Dockerfile сам читается билдером отдельно, в контекст не тянем)
+docker-compose.yml
+docker-compose.yaml
+.dockerignore
+
+# Docs / план
+*.md

--- a/.github/workflows/deploy_dev.yaml
+++ b/.github/workflows/deploy_dev.yaml
@@ -27,9 +27,11 @@ jobs:
             set -e
             cd ~/frontend_dev
             echo "[disk] before:" && df -h / | tail -1
+            docker system df || true
             docker container prune -f || true
-            docker image prune -af --filter "until=24h" || true
-            docker builder prune -af --filter "until=24h" || true
+            docker image prune -af || true
+            docker builder prune -af || true
+            docker volume prune -f || true
             echo "[disk] after prune:" && df -h / | tail -1
             git pull
             docker compose up --force-recreate -d --no-deps --remove-orphans --build frontend_dev

--- a/.github/workflows/deploy_prod.yaml
+++ b/.github/workflows/deploy_prod.yaml
@@ -23,9 +23,11 @@ jobs:
             set -e
             cd ~/frontend_prod
             echo "[disk] before:" && df -h / | tail -1
+            docker system df || true
             docker container prune -f || true
-            docker image prune -af --filter "until=24h" || true
-            docker builder prune -af --filter "until=24h" || true
+            docker image prune -af || true
+            docker builder prune -af || true
+            docker volume prune -f || true
             echo "[disk] after prune:" && df -h / | tail -1
             git pull
             docker compose up --force-recreate -d --no-deps --build frontend_prod --remove-orphans


### PR DESCRIPTION
- Без .dockerignore билд COPY . . затаскивал .output, node_modules, .git, .nuxt — каждый билд оставлял сотни МБ dangling-слоёв и убивал кэш.
- Сняли фильтр until=24h с docker prune (за сутки накапливалось столько слоёв, что фильтр их не доставал → no space left on device).
- Добавили docker volume prune и docker system df для видимости.